### PR TITLE
feat: 添加命令行图像导入和启动程序执行截图OCR功能

### DIFF
--- a/Snipping_OCR/Main.cs
+++ b/Snipping_OCR/Main.cs
@@ -118,6 +118,37 @@ namespace Snipping_OCR
                 TranslateSwitch();
                 TranslateCheck();
             }
+
+            // 命令行启动OCR
+            var CmdArgs = Environment.GetCommandLineArgs();
+            if (CmdArgs.Length > 1)
+            {
+                // 如果存在第二个参数，并且第一个参数是 capture，则第二个参数是文件路径
+                if (CmdArgs.Length > 2 && CmdArgs[1]== "capture")
+                {
+                    CmdArgs[1] = CmdArgs[2];
+                }
+
+                // 可以通过命令行调用所以需要判断文件是否存在
+                string file = CmdArgs[1];
+                if (File.Exists(file))
+                {
+                    string ext = file.ToLower().Substring(file.Length - 3);
+                    if (ImgAllow.Contains(ext))
+                    {
+                        sqPhoto.Image = Image.FromFile(file);
+                        timeOCR_Start();
+                    }
+                }
+                else
+                {
+                    // 快捷命令
+                    if (CmdArgs[1] == "capture")
+                    {
+                        StartCapture(); 
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Snipping_OCR/Snipping_OCR.csproj
+++ b/Snipping_OCR/Snipping_OCR.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>AnyCPU;x64</Platforms>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <Version>1.3.2</Version>
+    <Version>1.3.5</Version>
 	<Authors>SangSQ(桑世强)</Authors>
   </PropertyGroup>
 


### PR DESCRIPTION
本次更新增加了以下两个功能：

1. 命令行图像导入：现在你可以通过命令行导入图像进行 OCR 操作。这个功能使得 Snipping_OCR 可以被所有支持发送到其他程序的截图软件调用，类似于 ABBYY FineReader OCR 的操作方式。只需拖拽图像到程序快捷方式图标上，即可自动进行 OCR 工作。

2. 启动程序执行截图 OCR：现在，当你启动 Snipping_OCR 时，可以选择直接进行截图 OCR 操作。这个功能类似于 Text-Grab 的 "Open Fullscreen on Launch" 选项。

这两个新功能的添加，使得 Snipping_OCR 的交互方式更加快捷，用户体验进一步提升。感谢用户的建议和反馈，我们将继续努力提供更好的 OCR 解决方案。

#2 